### PR TITLE
changement ordre

### DIFF
--- a/startup.bat
+++ b/startup.bat
@@ -10,10 +10,10 @@ echo ======================================
 echo 1 - B-FLOW (WEB)
 echo 2 - B-FLOW (Mobile)
 echo 3 - VS Code
-echo 4 - Cities Skylines 2
-echo 5 - Geometry Dash
-echo 6 - Project 64
-echo 7 - Opera GX
+echo 4 - Opera GX
+echo 5 - Cities Skylines 2
+echo 6 - Geometry Dash
+echo 7 - Project 64
 echo 0 - Quitter
 echo ======================================
 set /p choice=Ton choix : 
@@ -21,10 +21,10 @@ set /p choice=Ton choix :
 if "%choice%"=="1" goto B_FLOW_WEB
 if "%choice%"=="2" goto B_FLOW_MOB
 if "%choice%"=="3" goto VS_CODE_ET_OPERA_GX
-if "%choice%"=="4" goto CITIES_SKYLINES_II
-if "%choice%"=="5" goto GEOMETRY_DASH
-if "%choice%"=="6" goto PROJECT_64
-if "%choice%"=="7" goto OPERA_GX
+if "%choice%"=="4" goto OPERA_GX
+if "%choice%"=="5" goto CITIES_SKYLINES_II
+if "%choice%"=="6" goto GEOMETRY_DASH
+if "%choice%"=="7" goto PROJECT_64
 if "%choice%"=="0" exit
 goto MENU
 
@@ -37,6 +37,10 @@ goto END
 start "" "C:\Users\berti\AppData\Local\Programs\Microsoft VS Code\Code.exe"
 start "" "C:\Program Files\Docker\Docker\Docker Desktop.exe"
 start "" "C:\Program Files\Android\Android Studio\bin\studio64.exe"
+goto END
+
+:OPERA_GX
+start "" "C:\Users\berti\AppData\Local\Programs\Opera GX\opera.exe"
 goto END
 
 :VS_CODE_ET_OPERA_GX
@@ -54,10 +58,6 @@ goto END
 
 :PROJECT_64
 start "" "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Project64 2.3\Project64.lnk"
-start "" "C:\Users\berti\AppData\Local\Programs\Opera GX\opera.exe"
-goto END
-
-:OPERA_GX
 start "" "C:\Users\berti\AppData\Local\Programs\Opera GX\opera.exe"
 goto END
 


### PR DESCRIPTION
## Summary by Sourcery

Reorder the launcher menu items and their choice handlers, introduce a separate Opera GX target section, and remove the redundant Opera GX block

Enhancements:
- Swap the positions of Opera GX, Cities Skylines 2, Geometry Dash, and Project 64 in the menu and choice conditions
- Add a dedicated :OPERA_GX label for launching Opera GX
- Eliminate the duplicated Opera GX startup block at the end of the script